### PR TITLE
MyBLE.m: add additional identifier for a cat printer

### DIFF
--- a/Print2BLE/MyBLE.m
+++ b/Print2BLE/MyBLE.m
@@ -51,8 +51,8 @@ const unsigned char ucMirror[256]=
 
 - (uint8_t)findPrinter: (const char *) name
 {
-    const char *szTypes[] = {"MTP-II", "MTP-2", "MTP-3", "MTP-3F", "PeriPage+", "PeriPage_", "GT01", "GT02", "GB01", "GB02", "YHK-54A8", NULL};
-    const uint8_t ucTypes[] = {PRINTER_MTP2, PRINTER_MTP2, PRINTER_MTP3, PRINTER_MTP3, PRINTER_PERIPAGEPLUS, PRINTER_PERIPAGE, PRINTER_CAT, PRINTER_CAT, PRINTER_CAT, PRINTER_CAT, PRINTER_PANDA};
+    const char *szTypes[] = {"MTP-II", "MTP-2", "MTP-3", "MTP-3F", "PeriPage+", "PeriPage_", "GT01", "GT02", "GB01", "GB02", "GB03", "YHK-54A8", NULL};
+    const uint8_t ucTypes[] = {PRINTER_MTP2, PRINTER_MTP2, PRINTER_MTP3, PRINTER_MTP3, PRINTER_PERIPAGEPLUS, PRINTER_PERIPAGE, PRINTER_CAT, PRINTER_CAT, PRINTER_CAT, PRINTER_CAT, PRINTER_CAT, PRINTER_PANDA};
     char szTemp[32];
     uint8_t ucType = 255; // invalid
     int i=0;


### PR DESCRIPTION
Simple addition of another model of the cat printer, GB03. This works fine i.e. the printer is detected and can be connected to. There are some outstanding issues (prints are seemingly too short), but I've tested this small change on Intel and M1 Pro Macs and the app connects and can send feed commands.