### PR TITLE
Sleep a bit if printer doesn’t support write with response

### DIFF
--- a/Print2BLE/MyBLE.m
+++ b/Print2BLE/MyBLE.m
@@ -243,11 +243,16 @@ didDiscoverServices:(NSError *)error
 - (void)writeData: (uint8_t *)pData withLength:(int)len withResponse:(bool)response
 {
     NSData *myData = [NSData dataWithBytes:pData length:len];
-    
-    if (response)
+    BOOL supportsResponse = (self.myChar.properties & CBCharacteristicPropertyWrite);
+    if (response && supportsResponse) {
         [_myPeripheral writeValue:myData forCharacteristic:_myChar type:CBCharacteristicWriteWithResponse];
-    else
+    } else {
         [_myPeripheral writeValue:myData forCharacteristic:_myChar type:CBCharacteristicWriteWithoutResponse];
+        if (response) {
+            // Must wait for a response but printer characteristic doesn't support it. Let's wait a bit instead.
+            usleep(100000);
+        }
+    }
 
 } /* writeData */
 


### PR DESCRIPTION
Some printers (MX06 cat) will freeze printing after a few lines if we send too much data. Asking to write with response doesn’t work since they don’t support it. The solution is to wait a bit instead.

I assume this is the same issue https://github.com/bitbank2/Print2BLE/issues/12.